### PR TITLE
ci: fix sync-upstream auto-resolve for modify/delete conflicts

### DIFF
--- a/.github/scripts/auto-resolve-merge-conflicts.sh
+++ b/.github/scripts/auto-resolve-merge-conflicts.sh
@@ -69,6 +69,10 @@ while IFS= read -r line; do
         fi
         continue
         ;;
+      *)
+        echo "::warning::VERSION file $file has unhandled conflict status $status - left for manual review"
+        continue
+        ;;
     esac
   fi
 
@@ -93,7 +97,11 @@ while IFS= read -r line; do
       UU|AU|UA)
         if is_in_array "$file" "${KEEP_WORKFLOWS[@]}"; then
           echo "  Resolve workflow (keep ours; content conflict): $file"
-          git checkout --ours -- "$file" && git add -- "$file"
+          if git checkout --ours -- "$file" 2>/dev/null; then
+            git add -- "$file"
+          else
+            echo "::warning::Cannot checkout --ours for $file ($status)"
+          fi
         else
           echo "  Resolve workflow (theirs; content conflict): $file"
           if git checkout --theirs -- "$file" 2>/dev/null; then
@@ -113,6 +121,10 @@ while IFS= read -r line; do
     esac
     continue
   fi
+
+  # Non-VERSION, non-workflow path with a conflict - left for manual review.
+  # Logged so it's easy to spot in CI output before the final summary.
+  echo "::warning::Conflict in $file ($status) - left for manual review"
 done < <(git status --porcelain | grep -E '^(UU|DU|UD|AA|DD|AU|UA) ' || true)
 
 # Report remaining conflicts; caller decides whether to abort or proceed (e.g. for PR fallback).

--- a/.github/scripts/auto-resolve-merge-conflicts.sh
+++ b/.github/scripts/auto-resolve-merge-conflicts.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Auto-resolve common merge conflicts after `git merge <upstream-tag>`.
+# Called by .github/workflows/sync-upstream.yml.
+#
+# Resolution rules:
+#   - VERSION_FILES (mix.exs, CHANGELOG.md, etc.): always take upstream content
+#   - .github/workflows/* in KEEP_WORKFLOWS: keep DOS version
+#       (these files are DOS-authored and must survive when upstream renames/deletes them)
+#   - .github/workflows/* not in KEEP_WORKFLOWS: prefer upstream content,
+#       accept either side's deletion (upstream-only files get pruned in the next step anyway)
+#
+# After this script runs, `git status` may still show unmerged paths for content
+# conflicts in non-workflow files. Exits 0 when fully resolved, 1 when conflicts remain.
+#
+# NOTE: deliberately does NOT use `set -e` so a single file failure does not
+# abort the whole batch (previous bug: a single `xargs git checkout --theirs`
+# failure on a modify/delete conflict killed the entire step with exit 123).
+
+set -uo pipefail
+
+VERSION_FILES=(
+  mix.exs
+  rel/config.exs
+  docker/Makefile
+  CHANGELOG.md
+  apps/block_scout_web/mix.exs
+  apps/ethereum_jsonrpc/mix.exs
+  apps/explorer/mix.exs
+  apps/indexer/mix.exs
+  apps/nft_media_handler/mix.exs
+  apps/utils/mix.exs
+)
+
+KEEP_WORKFLOWS=(
+  .github/workflows/deploy-config.yml
+  .github/workflows/publish-regular-docker-image-on-demand.yml
+  .github/workflows/sync-upstream.yml
+)
+
+is_in_array() {
+  local needle="$1"; shift
+  local hay
+  for hay in "$@"; do [ "$hay" = "$needle" ] && return 0; done
+  return 1
+}
+
+# `git status --porcelain` unmerged status codes (XY columns, see git-status(1)):
+#   DD  both deleted
+#   AU  added by us
+#   UD  deleted by them   (we modified, they deleted)
+#   UA  added by them
+#   DU  deleted by us     (we deleted, they modified)
+#   AA  both added
+#   UU  both modified
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  status="${line:0:2}"
+  file="${line:3}"
+
+  # VERSION_FILES: always take upstream (content conflict only)
+  if is_in_array "$file" "${VERSION_FILES[@]}"; then
+    case "$status" in
+      UU|AU|UA)
+        echo "  Resolve VERSION (theirs): $file"
+        if git checkout --theirs -- "$file" 2>/dev/null; then
+          git add -- "$file"
+        else
+          echo "::warning::Cannot checkout --theirs for $file ($status)"
+        fi
+        continue
+        ;;
+    esac
+  fi
+
+  # .github/workflows/*
+  if [[ "$file" == .github/workflows/* ]]; then
+    case "$status" in
+      DU)
+        # We deleted, upstream modified - keep our deletion.
+        echo "  Resolve workflow (keep our deletion): $file"
+        git rm -f -- "$file" >/dev/null 2>&1 || true
+        ;;
+      UD)
+        # We modified, upstream deleted.
+        if is_in_array "$file" "${KEEP_WORKFLOWS[@]}"; then
+          echo "  Resolve workflow (keep ours; upstream deleted): $file"
+          git add -- "$file"
+        else
+          echo "  Resolve workflow (drop; upstream deleted): $file"
+          git rm -f -- "$file" >/dev/null 2>&1 || true
+        fi
+        ;;
+      UU|AU|UA)
+        if is_in_array "$file" "${KEEP_WORKFLOWS[@]}"; then
+          echo "  Resolve workflow (keep ours; content conflict): $file"
+          git checkout --ours -- "$file" && git add -- "$file"
+        else
+          echo "  Resolve workflow (theirs; content conflict): $file"
+          if git checkout --theirs -- "$file" 2>/dev/null; then
+            git add -- "$file"
+          else
+            echo "::warning::Cannot checkout --theirs for $file ($status)"
+          fi
+        fi
+        ;;
+      DD)
+        echo "  Resolve workflow (both deleted): $file"
+        git rm -f -- "$file" >/dev/null 2>&1 || true
+        ;;
+      *)
+        echo "::warning::Unhandled workflow conflict status $status for $file"
+        ;;
+    esac
+    continue
+  fi
+done < <(git status --porcelain | grep -E '^(UU|DU|UD|AA|DD|AU|UA) ' || true)
+
+# Report remaining conflicts; caller decides whether to abort or proceed (e.g. for PR fallback).
+REMAINING=$(git diff --name-only --diff-filter=U)
+if [ -n "$REMAINING" ]; then
+  echo "::warning::Remaining unresolved conflicts:"
+  echo "$REMAINING" | sed 's/^/  - /'
+  exit 1
+fi
+
+exit 0

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -63,7 +63,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Files that MUST match upstream exactly (versions, deps, build config)
+          # Files that MUST match upstream exactly (versions, deps, build config).
+          # Kept in sync with .github/scripts/auto-resolve-merge-conflicts.sh.
           VERSION_FILES=(
             mix.exs
             rel/config.exs
@@ -81,39 +82,24 @@ jobs:
           if git merge "$TAG" --no-edit -m "Merge upstream $TAG"; then
             echo "Clean merge succeeded"
           else
-            # Merge failed — auto-resolve conflicts
+            # Merge failed - auto-resolve conflicts
             echo "::notice::Merge conflict detected, attempting auto-resolve..."
 
-            for f in "${VERSION_FILES[@]}"; do
-              if git diff --name-only --diff-filter=U | grep -qx "$f"; then
-                echo "  Auto-resolve (theirs): $f"
-                git checkout --theirs "$f"
-                git add "$f"
-              fi
-            done
-
-            # Accept upstream for ALL upstream workflow files (version bumps)
-            # Our custom workflows (docker-publish, deploy-config, sync-upstream) won't conflict
-            CONFLICT_WORKFLOWS=$(git diff --name-only --diff-filter=U | grep '^\.github/workflows/' || true)
-            if [ -n "$CONFLICT_WORKFLOWS" ]; then
-              echo "  Auto-resolve (theirs): workflow files"
-              echo "$CONFLICT_WORKFLOWS" | xargs git checkout --theirs
-              echo "$CONFLICT_WORKFLOWS" | xargs git add
-            fi
-
-            # Check if any conflicts remain
-            REMAINING=$(git diff --name-only --diff-filter=U || true)
-            if [ -n "$REMAINING" ]; then
+            if bash .github/scripts/auto-resolve-merge-conflicts.sh; then
+              git commit --no-edit -m "Merge upstream $TAG (auto-resolved conflicts)"
+            else
+              # Conflicts remain - capture list, abort merge, hand off to PR step.
+              REMAINING=$(git diff --name-only --diff-filter=U || true)
               echo "::warning::Unresolvable conflicts in: $REMAINING"
               git merge --abort
               echo "result=conflict" >> $GITHUB_OUTPUT
-              echo "conflict_files<<EOF" >> $GITHUB_OUTPUT
-              echo "$REMAINING" >> $GITHUB_OUTPUT
-              echo "EOF" >> $GITHUB_OUTPUT
+              {
+                echo "conflict_files<<EOF"
+                echo "$REMAINING"
+                echo "EOF"
+              } >> $GITHUB_OUTPUT
               exit 0
             fi
-
-            git commit --no-edit -m "Merge upstream $TAG (auto-resolved conflicts)"
           fi
 
           # Post-merge: ensure version files match upstream EXACTLY
@@ -217,14 +203,10 @@ jobs:
           git checkout -b "$BRANCH"
           git merge "$TAG" --no-edit || true
 
-          # Auto-resolve what we can (same strategy as above)
-          for f in mix.exs rel/config.exs docker/Makefile CHANGELOG.md apps/*/mix.exs; do
-            if git diff --name-only --diff-filter=U | grep -qx "$f" 2>/dev/null; then
-              git checkout --theirs "$f" && git add "$f"
-            fi
-          done
-          CONFLICT_WF=$(git diff --name-only --diff-filter=U | grep '^\.github/workflows/' || true)
-          [ -n "$CONFLICT_WF" ] && echo "$CONFLICT_WF" | xargs git checkout --theirs && echo "$CONFLICT_WF" | xargs git add
+          # Auto-resolve what we can. Script exits 1 when conflicts remain;
+          # that is expected here - we still commit and push the WIP state
+          # so reviewers see only the unresolvable conflicts.
+          bash .github/scripts/auto-resolve-merge-conflicts.sh || true
 
           git add -A
           git commit -m "WIP: Merge upstream $TAG (has conflicts)" --no-verify || true


### PR DESCRIPTION
## Problem

The scheduled `Sync upstream release` workflow has been failing every 6h since blockscout upstream tagged `v11.0.3`. Symptom:

```
error: path '.github/workflows/publish-regular-docker-image-on-demand.yml' does not have their version
##[error]Process completed with exit code 123.
```

Root cause: the auto-resolve step ran `xargs git checkout --theirs` on **all** conflicting workflow files in one batch. When upstream deletes a file we still keep (DU/UD modify-delete conflict), the checkout fails for that single path and `xargs` exits non-zero, killing the whole step under `set -eo pipefail`. Subsequent steps (including the `Create PR on conflict` fallback) are gated on `result == 'success'` and get skipped, so the workflow fails silently every cron tick with no PR to track the conflict.

Concretely, merging `v11.0.3` produces:

| Status | Count | Files |
|--------|-------|-------|
| `DU` (we deleted, upstream modified) | 44 | release-*.yml, publish-docker-image-*.yml, pre-release-*.yml |
| `UD` (we modified, upstream deleted) | 1 | publish-regular-docker-image-on-demand.yml (DOS-only) |
| `UU` (content conflict) | 1 | apps/indexer/test/indexer/fetcher/internal_transaction_test.exs |

The old logic only handled UU and assumed `--theirs` would always exist.

## Fix

Move resolution into `.github/scripts/auto-resolve-merge-conflicts.sh`, iterate per file, and dispatch on the porcelain status code:

- `DU` -> `git rm` (keep our deletion)
- `UD` -> `git add` if file is in `KEEP_WORKFLOWS`, else `git rm`
- `UU` (workflow files) -> `--ours` for KEEP, `--theirs` otherwise
- `UU` (non-workflow) -> leave for manual review, script exits 1

The merge step commits when the script exits 0; on exit 1 it aborts the merge and hands off to the existing `Create PR on conflict` step (which now reuses the same script instead of the buggy xargs).

## Local verification

Reproduced the v11.0.3 merge against current `main` in a worktree:

```
$ bash .github/scripts/auto-resolve-merge-conflicts.sh
  ... 44 deletions resolved ...
  Resolve workflow (keep ours; upstream deleted): .github/workflows/publish-regular-docker-image-on-demand.yml
::warning::Remaining unresolved conflicts:
  - apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
exit=1
```

Final state: 1 genuine content conflict in the indexer test, all 45 workflow conflicts auto-resolved as intended.

## Follow-up

After this merges, dispatching the workflow manually with `tag=v11.0.3` should produce a `sync-upstream-v11.0.3` PR containing only the test file conflict marker, which can then be resolved by hand.