### PR TITLE
fix(ci): sync-upstream prefers stable releases over prereleases

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -47,6 +47,12 @@ jobs:
               TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -ivE -- '-alpha' | head -1)
             fi
           fi
+
+          if [ -z "$TAG" ]; then
+            echo "::error::No upstream release tag matched 'v[0-9]*.[0-9]*.[0-9]*'. Aborting."
+            exit 1
+          fi
+
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "Target tag: $TAG"
 

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -39,8 +39,13 @@ jobs:
           if [ -n "${{ inputs.tag }}" ]; then
             TAG="${{ inputs.tag }}"
           else
-            # Get latest release tag from upstream (filter only vX.Y.Z pattern)
-            TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1)
+            # Prefer the newest STABLE release (no -alpha/-beta/-rc suffix).
+            # Fall back to the newest non-alpha prerelease (beta/rc) only when no
+            # stable release exists. Never auto-sync -alpha tags.
+            TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -vE -- '-' | head -1)
+            if [ -z "$TAG" ]; then
+              TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -ivE -- '-alpha' | head -1)
+            fi
           fi
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "Target tag: $TAG"


### PR DESCRIPTION
## Change
Mirror of the DOScan-Frontend fix (#6). Tag selection now prefers the newest **stable** release (no `-` suffix), falls back to newest non-alpha prerelease only if no stable exists, and never auto-syncs `-alpha`.

## Impact on backend
blockscout/blockscout currently publishes only stable `vX.Y.Z` tags, so selection is **unchanged** (still picks `v11.0.3`). This is a hardening / consistency change so the two repos share identical sync logic and the backend won't accidentally pull a prerelease if upstream ever tags one.

## Verified locally
OLD and NEW both pick `v11.0.3`. YAML validated.