### PR TITLE
fix: add frontend env for relaunched explorer

### DIFF
--- a/docker-compose/envs/common-frontend-scan.env
+++ b/docker-compose/envs/common-frontend-scan.env
@@ -1,0 +1,16 @@
+# DOS Chain relaunched mainnet explorer overrides.
+# Base configuration is loaded from common-frontend.env first.
+
+NEXT_PUBLIC_APP_HOST=scan.doschain.com
+NEXT_PUBLIC_NETWORK_RPC_URL=https://main3.doschain.com
+
+NEXT_PUBLIC_API_HOST=scan.doschain.com
+NEXT_PUBLIC_STATS_API_HOST=https://scan.doschain.com
+NEXT_PUBLIC_STATS_API_BASE_PATH=/stats-api
+NEXT_PUBLIC_VISUALIZE_API_HOST=https://scan.doschain.com/visualize
+
+NEXT_PUBLIC_HAS_USER_OPS=false
+NEXT_PUBLIC_HOMEPAGE_STATS=['total_blocks','average_block_time','total_txs','wallet_addresses','gas_tracker']
+NEXT_PUBLIC_NETWORK_EXPLORERS=[{'title':'DOS Chain','baseUrl':'https://scan.doschain.com/','paths':{'tx':'/tx','address':'/address','token':'/token','block':'/block'}}]
+NEXT_PUBLIC_WEB3_WALLETS=none
+


### PR DESCRIPTION
## Summary
- add a dedicated frontend override env for scan.doschain.com
- keep common-frontend.env as the base source of network and UI configuration
- preserve the nDOS gas denomination from the base env

## Verification
- metados/blockscout-frontend:2.9.4 starts successfully with both env files
- runtime assets/envs.js contains NEXT_PUBLIC_NETWORK_CURRENCY_GWEI_NAME=nDOS
- production homepage, API, and stats endpoints return HTTP 200